### PR TITLE
:bug: 이미지 비율 수정

### DIFF
--- a/StyleChanger.xcodeproj/project.pbxproj
+++ b/StyleChanger.xcodeproj/project.pbxproj
@@ -73,9 +73,9 @@
 			isa = PBXGroup;
 			children = (
 				799D847E2931EE03004A70C2 /* Controller */,
+				799EAF6629377A2C0067430F /* ML */,
 				799D8459292F5CDE004A70C2 /* AppDelegate.swift */,
 				799D845B292F5CDE004A70C2 /* SceneDelegate.swift */,
-				799EAF6629377A2C0067430F /* ML */,
 				799D8462292F5CE0004A70C2 /* Assets.xcassets */,
 				799D84782931E7CB004A70C2 /* 나눔손글씨 강인한 위로.ttf */,
 				799D8464292F5CE0004A70C2 /* LaunchScreen.storyboard */,

--- a/StyleChanger/Controller/TransViewController.swift
+++ b/StyleChanger/Controller/TransViewController.swift
@@ -17,12 +17,13 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
     
     private var imageView: UIImageView = {
         var image = UIImageView(image: UIImage(named: "blackpaper"))
+        image.contentMode = .scaleAspectFill
         image.translatesAutoresizingMaskIntoConstraints = false
         return image
     }()
     
     private let segmentButton: UISegmentedControl = {
-        var segment = UISegmentedControl(items: ["Stone", "Draw", "Pencil", "Spring", "Dot", "Green"] )
+        var segment = UISegmentedControl(items: ["Stone", "Draw", "Pencil", "Spring", "Dot", "Green"])
         segment.selectedSegmentIndex = 0
         segment.translatesAutoresizingMaskIntoConstraints = false
         return segment
@@ -91,7 +92,7 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
     }
     
     private func detect(image: CIImage, name: String) {
-    
+        
         var model: VNCoreMLModel?
         
         switch name {
@@ -160,17 +161,17 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
     private func setConstraints() {
         
         let imageViewConstraints = [
-            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+//            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 124),
-            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 42),
-            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42),
-            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: 1.0)
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 136),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -136),
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 1.2)
         ]
         
         let segmentButtonConstraints = [
             segmentButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            //            segmentButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 42),
-            //            segmentButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42),
+            segmentButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 42),
+            segmentButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42),
             segmentButton.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 75)
         ]
         


### PR DESCRIPTION
## 작업 내용
1:1 이미지가 아닌 다른 비율의 이미지를 넣을 시, 이미지가 이상하게 보이는 현상을 수정하였습니다.

## 스크린샷
|TransView|
|---|
|<img src = "https://user-images.githubusercontent.com/66102708/205430783-9fb99825-0734-4ac8-bdcc-1208a691b4fc.jpeg" width = 500> |

## 리뷰 포인트
 - content를 Fit이 아닌 Fill로 수정하였습니다.
 - AutoLayout 비율을 맞추었습니다.
