### PR TITLE
:bug: 이미지 스타일 변경 시 이미지 돌아감 수정

### DIFF
--- a/StyleChanger/Controller/TransViewController.swift
+++ b/StyleChanger/Controller/TransViewController.swift
@@ -13,7 +13,9 @@ import Photos
 class TransViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     
     @objc let imagePicker = UIImagePickerController()
-    var userImage: CIImage!
+    var userCIImage: CIImage!
+    var userUIImage: UIImage!
+    var ratio: CGFloat = 0
     
     private var imageView: UIImageView = {
         var image = UIImageView(image: UIImage(named: "blackpaper"))
@@ -61,31 +63,34 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         
-        if let userPickedImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            self.imageView.image = userPickedImage
-            userImage = CIImage(image: userPickedImage)!
-            userImage.orientationTransform(for: .up)
-        }
+        guard let userPickedImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }
+        userUIImage = userPickedImage
+        ratio = userUIImage.size.width / userUIImage.size.height
+        self.imageView.image = userUIImage
+        
+        userCIImage = CIImage(image: userPickedImage)!
+        userCIImage.orientationTransform(for: .up)
+        
         imagePicker.dismiss(animated: true)
     }
     
     @objc func segmentControl(_ segmentedControl: UISegmentedControl) {
         
-        guard userImage != nil else { return }
+        guard userCIImage != nil else { return }
         
         switch segmentedControl.selectedSegmentIndex {
         case 0:
-            detect(image: userImage, name: "Stone")
+            detect(image: userCIImage, name: "Stone")
         case 1:
-            detect(image: userImage, name: "Dezoomify1teration310")
+            detect(image: userCIImage, name: "Dezoomify1teration310")
         case 2:
-            detect(image: userImage, name: "Pencil")
+            detect(image: userCIImage, name: "Pencil")
         case 3:
-            detect(image: userImage, name: "Spring")
+            detect(image: userCIImage, name: "Spring")
         case 4:
-            detect(image: userImage, name: "Dot")
+            detect(image: userCIImage, name: "Dot")
         case 5:
-            detect(image: userImage, name: "Green")
+            detect(image: userCIImage, name: "Green")
         default:
             break
         }
@@ -113,7 +118,6 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
         }
         
         let request = VNCoreMLRequest(model: model!) { request, _ in
-            
             DispatchQueue.global(qos: .userInteractive).async {
                 guard let results = request.results?.first as? VNPixelBufferObservation else {
                     fatalError("model failed to process image")
@@ -121,20 +125,31 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
                 let pixelBuffer = results.pixelBuffer
                 
                 let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-                
+                let image = UIImage(ciImage: ciImage)
                 DispatchQueue.main.async {
-                    self.imageView.image = UIImage(ciImage: ciImage)
+                    self.imageView.image = image
                 }
             }
-            
         }
         
-        let handler = VNImageRequestHandler(ciImage: image)
+        let orientation: CGImagePropertyOrientation = {
+            print(ratio)
+            switch ratio {
+            case 0.75:
+                return .right
+            default:
+                return .up
+            }
+        }()
+        
+        let handler = VNImageRequestHandler(ciImage: image, orientation: orientation)
+        
         do {
             try handler.perform([request])
         } catch {
             print(error)
         }
+        
     }
     
     @objc private func saveTransImage() {
@@ -161,7 +176,7 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
     private func setConstraints() {
         
         let imageViewConstraints = [
-//            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            //            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 124),
             imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 136),
             imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -136),


### PR DESCRIPTION
## 작업 내용
 - 이미지 스타일 변경 시 이미지가 회전되는 오류를 수정하였습니다. 

## 스크린샷
|iPad 12.9 inch, 3:4 비율 사진|iPad 12.9inch, 1:1 비율 사진|
|---|---|
| <img src = "https://user-images.githubusercontent.com/66102708/205503350-57cc9c17-9741-4d94-a027-407bb9cbff69.jpeg" width = 500> | <img src = "https://user-images.githubusercontent.com/66102708/205503426-f598f4bc-54a4-4b1e-9f31-9ee410004700.jpeg" width = 500>


## 리뷰 포인트
 - 이미지의 Vision 처리 시 이미지가 회전하는 것으로 보입니다. 
 - 이미지의 비율에 따라 orientaion을 고정시켜주었습니다.

## 다음으로 진행될 작업
 - [ ] 특정 이미지(비율 등)에 따라 이미지가 회전 또는 반전되는 경우가 있음. 해결 필요.

## 질문
 - [ ] CoreML Vision 처리시 이미지가 회전 혹은 반전되는 경우가 있는데 왜 그런 것인지 찾아볼 필요성이 있음.

