### PR TITLE
:sparkles: [Feat]스타일 변경 오리지널 이미지 세그먼트 추가

### DIFF
--- a/StyleChanger/Controller/TransViewController.swift
+++ b/StyleChanger/Controller/TransViewController.swift
@@ -25,7 +25,7 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
     }()
     
     private let segmentButton: UISegmentedControl = {
-        var segment = UISegmentedControl(items: ["Stone", "Draw", "Pencil", "Spring", "Dot", "Green"])
+        var segment = UISegmentedControl(items: ["Original", "Stone", "Draw", "Pencil", "Spring", "Dot", "Green"])
         segment.selectedSegmentIndex = 0
         segment.translatesAutoresizingMaskIntoConstraints = false
         return segment
@@ -80,16 +80,18 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
         
         switch segmentedControl.selectedSegmentIndex {
         case 0:
-            detect(image: userCIImage, name: "Stone")
+            imageView.image = userUIImage
         case 1:
-            detect(image: userCIImage, name: "Dezoomify1teration310")
+            detect(image: userCIImage, name: "Stone")
         case 2:
-            detect(image: userCIImage, name: "Pencil")
+            detect(image: userCIImage, name: "Dezoomify1teration310")
         case 3:
-            detect(image: userCIImage, name: "Spring")
+            detect(image: userCIImage, name: "Pencil")
         case 4:
-            detect(image: userCIImage, name: "Dot")
+            detect(image: userCIImage, name: "Spring")
         case 5:
+            detect(image: userCIImage, name: "Dot")
+        case 6:
             detect(image: userCIImage, name: "Green")
         default:
             break
@@ -133,7 +135,7 @@ class TransViewController: UIViewController, UIImagePickerControllerDelegate, UI
         }
         
         let orientation: CGImagePropertyOrientation = {
-            print(ratio)
+            
             switch ratio {
             case 0.75:
                 return .right


### PR DESCRIPTION
## 작업 내용
스타일 체인지할 시 original 이미지를 다시 볼 수 있게 세그먼트를 추가하였습니다.

## 스크린샷
|iPhone 12.9inch, 화면이름|
|---|
|<img src = "https://user-images.githubusercontent.com/66102708/206909497-1a3da4fa-73fe-4cdd-9267-c4731d17e346.png" width = 500> | 

## 메모
 - 실기기 테스트 진행을 하지 못한 상태입니다.
